### PR TITLE
Avatar Optimizerを使用している環境での挙動を改善

### DIFF
--- a/Editor/NDMFPlugin.cs
+++ b/Editor/NDMFPlugin.cs
@@ -7,22 +7,33 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
 {
     public class NDMFPlugin : Plugin<NDMFPlugin>
     {
+        public override string DisplayName => $"PhysBones Switcher";
+        public override string QualifiedName => "com.matcha-soft.physbones-switcher";
+
         protected override void Configure()
         {
             InPhase(BuildPhase.Generating)
                 .BeforePlugin("nadena.dev.modular-avatar")
-                .Run("Run PhysBones Switcher Processes", ctx => Processing(ctx));
+                .Run("Run PhysBones Switcher Processes (Generating Phase)", ctx => GeneratingPhaseProcess(ctx));
+
+#if AVATAR_OPTIMIZER
+            // VRC PhysBone の走査は Avatar Optimizer によるの最適化後に実行する
+            InPhase(BuildPhase.Optimizing)
+                .AfterPlugin("com.anatawa12.avatar-optimizer")
+                .Run("Run PhysBones Switcher Processes (Optimizing Phase)", ctx => OptimizingPhaseProcess(ctx));
+#endif
         }
 
-        private void Processing(BuildContext ctx)
-        {
-            PhysBonesSwitcherProcess(ctx);
-        }
-
-        private void PhysBonesSwitcherProcess(BuildContext ctx)
+        private void GeneratingPhaseProcess(BuildContext ctx)
         {
             var processor = new PhysBonesSwitcherProcessor();
-            processor.Run(ctx);
+            processor.GeneratingProcess(ctx);
+        }
+
+        private void OptimizingPhaseProcess(BuildContext ctx)
+        {
+            var processor = new PhysBonesSwitcherProcessor();
+            processor.OptimizingProcess(ctx);
         }
     }
 }

--- a/Editor/PhysBonesSwitcherState.cs
+++ b/Editor/PhysBonesSwitcherState.cs
@@ -1,0 +1,7 @@
+namespace MitarashiDango.PhysBonesSwitcher.Editor
+{
+    public class PhysBonesSwitcherState
+    {
+        public bool NeedOptimizingPhaseProcessing { get; set; }
+    }
+}

--- a/Editor/PhysBonesSwitcherState.cs.meta
+++ b/Editor/PhysBonesSwitcherState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d1e9d2467a1ccb4c9b86d6e0519e7f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/com.matcha-soft.physbones-switcher.editor.asmdef
+++ b/Editor/com.matcha-soft.physbones-switcher.editor.asmdef
@@ -8,6 +8,8 @@
         "GUID:62ced99b048af7f4d8dfe4bed8373d76",
         "GUID:fe747755f7b44e048820525b07f9b956",
         "GUID:fc900867c0f47cd49b6e2ae4ef907300",
+        "GUID:f69eeb3e25674f4a9bd20e6d7e69e0e6",
+        "GUID:ac4815c6727e4e34b9e13bb042cbc029",
         "GUID:1e20391fc4501a04586962d8c9939bee"
     ],
     "includePlatforms": [
@@ -19,6 +21,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.anatawa12.avatar-optimizer",
+            "expression": "[1.6,2.0)",
+            "define": "AVATAR_OPTIMIZER"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
- Avatar Optimizer の Merge PhysBone コンポーネントによってマージされた VRC PhysBone についても動的にオンオフできるよう変更
  - Optimizing フェーズでも VRC PhysBone コンポーネントの走査を行い、差分があればアニメーションへ追加する