### PR TITLE
Write Defaults設定を明示的に行えるよう変更

### DIFF
--- a/Editor/Inspector/PhysBonesSwitcherEditor.cs
+++ b/Editor/Inspector/PhysBonesSwitcherEditor.cs
@@ -29,6 +29,13 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
                 label = "カスタム遅延時間(秒)"
             });
 
+            root.Add(new EnumField
+            {
+                bindingPath = "writeDefaultsMode",
+                label = "Write Defaults 設定",
+                style = { flexGrow = 1 },
+            });
+
             root.Add(CreateExcludeObjectSettingsListView());
 
             return root;

--- a/Editor/PhysBonesSwitcherProcessor.cs
+++ b/Editor/PhysBonesSwitcherProcessor.cs
@@ -37,6 +37,7 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
             state.excludeObjectSettings = physBonesSwitcher.excludeObjectSettings;
             state.customDelayTime = physBonesSwitcher.customDelayTime;
             state.physBoneOffAudioClip = physBonesSwitcher.physBoneOffAudioClip;
+            state.writeDefaultsMode = physBonesSwitcher.writeDefaultsMode;
 #if AVATAR_OPTIMIZER
             state.NeedOptimizingPhaseProcessing = true;
 #endif
@@ -61,7 +62,7 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
             mergeAnimator.animator = animatorController;
             mergeAnimator.layerType = AnimLayerType.FX;
             mergeAnimator.pathMode = MergeAnimatorPathMode.Absolute;
-            mergeAnimator.matchAvatarWriteDefaults = true;
+            mergeAnimator.matchAvatarWriteDefaults = physBonesSwitcher.writeDefaultsMode == Runtime.WriteDefaultsMode.MatchAvatarWriteDefaults;
 
             Object.DestroyImmediate(physBonesSwitcher);
         }
@@ -519,11 +520,11 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
             };
 
             var initialState = layer.stateMachine.AddState("Initial State", new Vector3(-20, 60, 0));
-            initialState.writeDefaultValues = false;
+            initialState.writeDefaultValues = state.writeDefaultsMode == Runtime.WriteDefaultsMode.WriteDefaultsOn;
             initialState.motion = blankAnimationClip;
 
             var setPhysBoneOnState = layer.stateMachine.AddState("Set PhysBone ON", new Vector3(220, 60, 0));
-            setPhysBoneOnState.writeDefaultValues = false;
+            setPhysBoneOnState.writeDefaultValues = state.writeDefaultsMode == Runtime.WriteDefaultsMode.WriteDefaultsOn;
             setPhysBoneOnState.motion = blankAnimationClip;
             setPhysBoneOnState.behaviours = new StateMachineBehaviour[]
             {
@@ -541,7 +542,7 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
                 .SetImmediateTransitionSettings();
 
             var setPhysBoneOffState = layer.stateMachine.AddState("Set PhysBone OFF", new Vector3(-20, 140, 0));
-            setPhysBoneOffState.writeDefaultValues = false;
+            setPhysBoneOffState.writeDefaultValues = state.writeDefaultsMode == Runtime.WriteDefaultsMode.WriteDefaultsOn;
             setPhysBoneOffState.motion = blankAnimationClip;
             setPhysBoneOffState.behaviours = new StateMachineBehaviour[]
             {
@@ -576,7 +577,7 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
             AnimationUtility.SetEditorCurve(sleepAnimationClip, dummyBinding, dummyCurve);
 
             var sleepState = layer.stateMachine.AddState("Sleep", new Vector3(220, 140, 0));
-            sleepState.writeDefaultValues = false;
+            sleepState.writeDefaultValues = state.writeDefaultsMode == Runtime.WriteDefaultsMode.WriteDefaultsOn;
             sleepState.motion = sleepAnimationClip;
 
             AnimatorTransitionUtil.AddTransition(setPhysBoneOnState, sleepState)
@@ -617,6 +618,8 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
 
         private AnimatorControllerLayer GeneratePhysBonesSwitcherLayer(BuildContext ctx)
         {
+            var state = ctx.GetState<PhysBonesSwitcherState>();
+
             var layer = new AnimatorControllerLayer
             {
                 name = LayerNamePbsPhysBonesSwitcher,
@@ -631,10 +634,11 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
             var (blankAnimationClip, toEnableAnimationClip, toDisableAnimationClip) = GenerateAnimationClips(ctx);
 
             var initialState = layer.stateMachine.AddState("Initial State", new Vector3(-20, 60, 0));
-            initialState.writeDefaultValues = false;
+            initialState.writeDefaultValues = state.writeDefaultsMode == Runtime.WriteDefaultsMode.WriteDefaultsOn;
             initialState.motion = blankAnimationClip;
 
             var physBonesOnState = layer.stateMachine.AddState(StateNamePhysBonesON, new Vector3(220, 60, 0));
+            physBonesOnState.writeDefaultValues = state.writeDefaultsMode == Runtime.WriteDefaultsMode.WriteDefaultsOn;
             physBonesOnState.motion = toEnableAnimationClip;
 
             AnimatorTransitionUtil.AddTransition(initialState, physBonesOnState)
@@ -642,6 +646,7 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
                 .SetImmediateTransitionSettings();
 
             var physBonesOffState = layer.stateMachine.AddState(StateNamePhysBonesOFF, new Vector3(-20, 140, 0));
+            physBonesOffState.writeDefaultValues = state.writeDefaultsMode == Runtime.WriteDefaultsMode.WriteDefaultsOn;
             physBonesOffState.motion = toDisableAnimationClip;
 
             AnimatorTransitionUtil.AddTransition(initialState, physBonesOffState)
@@ -707,10 +712,11 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
             toDisableAnimationClip.SetCurve(path, typeof(GameObject), "m_IsActive", toDisableCurve);
 
             var initialState = layer.stateMachine.AddState("Initial State", new Vector3(-20, 60, 0));
-            initialState.writeDefaultValues = false;
+            initialState.writeDefaultValues = state.writeDefaultsMode == Runtime.WriteDefaultsMode.WriteDefaultsOn;
             initialState.motion = blankAnimationClip;
 
             var physBoneDisableSoundOnState = layer.stateMachine.AddState(StateNamePhysBoneDisableSoundON, new Vector3(220, 60, 0));
+            physBoneDisableSoundOnState.writeDefaultValues = state.writeDefaultsMode == Runtime.WriteDefaultsMode.WriteDefaultsOn;
             physBoneDisableSoundOnState.motion = toEnableAnimationClip;
 
             AnimatorTransitionUtil.AddTransition(initialState, physBoneDisableSoundOnState)
@@ -719,6 +725,7 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
                 .SetImmediateTransitionSettings();
 
             var physBoneDisableSoundOffState = layer.stateMachine.AddState(StateNamePhysBoneDisableSoundOFF, new Vector3(-20, 140, 0));
+            physBoneDisableSoundOffState.writeDefaultValues = state.writeDefaultsMode == Runtime.WriteDefaultsMode.WriteDefaultsOn;
             physBoneDisableSoundOffState.motion = toDisableAnimationClip;
 
             AnimatorTransitionUtil.AddTransition(initialState, physBoneDisableSoundOffState)

--- a/Editor/PhysBonesSwitcherState.cs
+++ b/Editor/PhysBonesSwitcherState.cs
@@ -10,5 +10,6 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
         public List<ExcludeObjectSetting> excludeObjectSettings { get; set; }
         public int customDelayTime { get; set; }
         public AudioClip physBoneOffAudioClip { get; set; }
+        public WriteDefaultsMode writeDefaultsMode { get; set; }
     }
 }

--- a/Runtime/PhysBonesSwitcher.cs
+++ b/Runtime/PhysBonesSwitcher.cs
@@ -22,5 +22,10 @@ namespace MitarashiDango.PhysBonesSwitcher.Runtime
         /// PhysBone無効化時の効果音
         /// </summary>
         public AudioClip physBoneOffAudioClip = null;
+
+        /// <summary>
+        /// Write Defaults 設定
+        /// </summary>
+        public WriteDefaultsMode writeDefaultsMode = WriteDefaultsMode.MatchAvatarWriteDefaults;
     }
 }

--- a/Runtime/WriteDefaultsMode.cs
+++ b/Runtime/WriteDefaultsMode.cs
@@ -1,0 +1,9 @@
+namespace MitarashiDango.PhysBonesSwitcher.Runtime
+{
+    public enum WriteDefaultsMode
+    {
+        MatchAvatarWriteDefaults = 0,
+        WriteDefaultsOn = 1,
+        WriteDefaultsOff = 2,
+    }
+}

--- a/Runtime/WriteDefaultsMode.cs.meta
+++ b/Runtime/WriteDefaultsMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b3519eed99d8cc45b4fcdb08b659e55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Write Defaults設定を明示的に行えるよう、設定項目を追加する。
なお、デフォルト値は項目追加前と同じである、アバター側Animator Controllerの値へ合わせる設定とする。

ref https://github.com/MitarashiDango/physbones-switcher/issues/11