### PR TITLE
VRC Phys Boneコンポーネントを操作するためのアニメーションの生成をOptimizing Phaseで行うか選択可能にする設定項目を追加

### DIFF
--- a/Editor/PhysBonesSwitcherProcessor.cs
+++ b/Editor/PhysBonesSwitcherProcessor.cs
@@ -39,10 +39,7 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
             state.customDelayTime = physBonesSwitcher.customDelayTime;
             state.physBoneOffAudioClip = physBonesSwitcher.physBoneOffAudioClip;
             state.writeDefaultsMode = physBonesSwitcher.writeDefaultsMode;
-
-#if AVATAR_OPTIMIZER
-            state.deferPhysBonesControlAnimationGeneration = true;
-#endif
+            state.deferPhysBonesControlAnimationGeneration = physBonesSwitcher.generatePhysBoneAnimationsInOptimizingPhase;
 
             var physBonesSwitcherGameObject = CreatePhysBonesSwitcherGameObject(ctx);
             var physBoneOffAudioSourceGameObject = AddPhysBoneDisableAudioSource(ctx, physBonesSwitcherGameObject);

--- a/Editor/Resources/UI/PhysBonesSwitcherEditor.uxml
+++ b/Editor/Resources/UI/PhysBonesSwitcherEditor.uxml
@@ -9,4 +9,6 @@
     <ui:EnumField label="Write Defaults 設定" type="MitarashiDango.PhysBonesSwitcher.Runtime.WriteDefaultsMode, com.matcha-soft.physbones-switcher.runtime" binding-path="writeDefaultsMode" name="write-defaults-mode-enum-field" />
     <ui:ListView binding-path="excludeObjectSettings" reorder-mode="Animated" show-add-remove-footer="true" show-border="true" show-foldout-header="true" virtualization-method="DynamicHeight" header-title="操作対象外オブジェクト" name="exclude-object-settings-listview" />
     <ui:Toggle name="disable-phys-bones-separation-toggle" binding-path="disablePhysBonesSeparation" text="PhysBone の自動分離処理を無効化する" />
+    <ui:Toggle name="generate-phys-bone-animations-in-optimizing-phase-toggle" binding-path="generatePhysBoneAnimationsInOptimizingPhase" text="PhysBone 操作アニメーションの生成を Optimizing Phase で行う" />
+    <ui:HelpBox text="VRC Phys Bone コンポーネントの追加・削除を行う他の拡張機能と併用する場合、操作アニメーションの生成を Optimizing Phase で行う必要があります" message-type="info" />
 </ui:UXML>

--- a/Editor/com.matcha-soft.physbones-switcher.editor.asmdef
+++ b/Editor/com.matcha-soft.physbones-switcher.editor.asmdef
@@ -9,8 +9,6 @@
         "GUID:901e56b065a857d4483a77f8cae73588",
         "GUID:fe747755f7b44e048820525b07f9b956",
         "GUID:fc900867c0f47cd49b6e2ae4ef907300",
-        "GUID:f69eeb3e25674f4a9bd20e6d7e69e0e6",
-        "GUID:ac4815c6727e4e34b9e13bb042cbc029",
         "GUID:1e20391fc4501a04586962d8c9939bee"
     ],
     "includePlatforms": [
@@ -22,12 +20,6 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [
-        {
-            "name": "com.anatawa12.avatar-optimizer",
-            "expression": "[1.6,2.0)",
-            "define": "AVATAR_OPTIMIZER"
-        }
-    ],
+    "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Runtime/PhysBonesSwitcher.cs
+++ b/Runtime/PhysBonesSwitcher.cs
@@ -33,5 +33,10 @@ namespace MitarashiDango.PhysBonesSwitcher.Runtime
         /// PhysBoneの自動分離処理を無効化する
         /// </summary>
         public bool disablePhysBonesSeparation = false;
+
+        /// <summary>
+        /// VRC Phys Bone コンポーネントを操作するアニメーションを Optimizing Phase で生成するかどうか
+        /// </summary>
+        public bool generatePhysBoneAnimationsInOptimizingPhase = false;
     }
 }


### PR DESCRIPTION
## 概要
他の拡張機能と干渉して正常に動作しなくなることを回避するため、ユーザーが明示的にアニメーション生成を遅延させられる設定項目を新設する。

## 備考
本項目の新設に伴い、従来は自動で行っていた、Avatar Optimizer対策の処理については削除を実施。(ユーザー側で明示的に設定を行う方針へ変更)