### PR TITLE
Vehicle Modeの設定値を保存するか選択できるようにする設定項目を追加

### DIFF
--- a/Editor/PhysBonesSwitcherParameters.cs
+++ b/Editor/PhysBonesSwitcherParameters.cs
@@ -11,7 +11,7 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
         public static readonly string VehicleMode = "PBS_VehicleMode";
         public static readonly string VehicleModeDelayType = "PBS_VehicleModeDelayType";
 
-        public List<ParameterConfig> GetParameterConfigs()
+        public List<ParameterConfig> GetParameterConfigs(bool vehicleModeSaved)
         {
             var parameterConfigs = new List<ParameterConfig>
             {
@@ -44,7 +44,7 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
                     nameOrPrefix = VehicleMode,
                     defaultValue = 0,
                     syncType = ParameterSyncType.Bool,
-                    saved = false,
+                    saved = vehicleModeSaved,
                     localOnly = true,
                 },
                 new ParameterConfig

--- a/Editor/PhysBonesSwitcherProcessor.cs
+++ b/Editor/PhysBonesSwitcherProcessor.cs
@@ -204,7 +204,7 @@ namespace MitarashiDango.PhysBonesSwitcher.Editor
         {
             var parameters = new PhysBonesSwitcherParameters();
             var modularAvatarParameters = physBonesSwitcher.gameObject.AddComponent<ModularAvatarParameters>();
-            modularAvatarParameters.parameters = parameters.GetParameterConfigs();
+            modularAvatarParameters.parameters = parameters.GetParameterConfigs(physBonesSwitcher.vehicleModeSaved);
         }
 
         private void AddMenuItems(BuildContext ctx, Runtime.PhysBonesSwitcher physBonesSwitcher)

--- a/Editor/Resources/UI/PhysBonesSwitcherEditor.uxml
+++ b/Editor/Resources/UI/PhysBonesSwitcherEditor.uxml
@@ -10,5 +10,6 @@
     <ui:ListView binding-path="excludeObjectSettings" reorder-mode="Animated" show-add-remove-footer="true" show-border="true" show-foldout-header="true" virtualization-method="DynamicHeight" header-title="操作対象外オブジェクト" name="exclude-object-settings-listview" />
     <ui:Toggle name="disable-phys-bones-separation-toggle" binding-path="disablePhysBonesSeparation" text="PhysBone の自動分離処理を無効化する" />
     <ui:Toggle name="generate-phys-bone-animations-in-optimizing-phase-toggle" binding-path="generatePhysBoneAnimationsInOptimizingPhase" text="PhysBone 操作アニメーションの生成を Optimizing Phase で行う" />
+    <ui:Toggle binding-path="vehicleModeSaved" text="Vehicle Mode の設定値を保存する" />
     <ui:HelpBox text="VRC Phys Bone コンポーネントの追加・削除を行う他の拡張機能と併用する場合、操作アニメーションの生成を Optimizing Phase で行う必要があります" message-type="info" />
 </ui:UXML>

--- a/Runtime/PhysBonesSwitcher.cs
+++ b/Runtime/PhysBonesSwitcher.cs
@@ -38,5 +38,10 @@ namespace MitarashiDango.PhysBonesSwitcher.Runtime
         /// VRC Phys Bone コンポーネントを操作するアニメーションを Optimizing Phase で生成するかどうか
         /// </summary>
         public bool generatePhysBoneAnimationsInOptimizingPhase = false;
+
+        /// <summary>
+        /// Vehicle Mode の設定値を保存するかどうか
+        /// </summary>
+        public bool vehicleModeSaved = false;
     }
 }


### PR DESCRIPTION
毎回設定するのが面倒なため、設定値を保存する設定でビルドを行えるようにする。
※初期設定は従来通り値を保存しない(インスタンスにJoinする度に都度設定がリセットされる)設定。